### PR TITLE
fix(core): route translation add more stability and example

### DIFF
--- a/packages/core/src/router/index.ts
+++ b/packages/core/src/router/index.ts
@@ -1,2 +1,3 @@
 export * from './router';
+export * from './route.interface';
 export * from './title-resolver';

--- a/packages/core/src/router/route.interface.ts
+++ b/packages/core/src/router/route.interface.ts
@@ -1,0 +1,8 @@
+import { Route } from '@angular/router';
+
+export type SdgRoutes = SdgRoute[];
+
+export interface SdgRoute extends Route {
+  /** Hidden in the primary tabs navigation */
+  hidden?: boolean;
+}

--- a/packages/core/src/router/router.ts
+++ b/packages/core/src/router/router.ts
@@ -1,16 +1,17 @@
 import { Route } from '@angular/router';
 
-import { TitleResolver } from './title-resolver';
+import { TitleResolver } from './title-resolver/title-resolver';
 
 export const RouteTitleKey = 'RouteTitle';
+export const RouteTranslateKey = 'TranslateKey';
 
-export function hasStaticTitle(config: Route): boolean {
+function hasStaticTitle(config: Route): boolean {
   return typeof config.title === 'string' || config.title === null;
 }
 
-export function getRouteTitle(
+export function resolveTitle(
   config: Route,
-  titleResolver?: TitleResolver<string>
+  titleResolver?: TitleResolver
 ): string | undefined {
   if (hasStaticTitle(config)) {
     return config.title as string;
@@ -19,6 +20,8 @@ export function getRouteTitle(
       return config.data[RouteTitleKey];
     }
 
-    return titleResolver?.resolveStatic(config);
+    return (
+      titleResolver?.resolveStatic(config) ?? config.data?.[RouteTranslateKey] // try to fallback on the translation key
+    );
   }
 }

--- a/packages/core/src/router/title-resolver/index.ts
+++ b/packages/core/src/router/title-resolver/index.ts
@@ -1,0 +1,2 @@
+export * from './title-resolver';
+export * from './title-resolver.pipe';

--- a/packages/core/src/router/title-resolver/title-resolver.pipe.spec.ts
+++ b/packages/core/src/router/title-resolver/title-resolver.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { TitleResolverPipe } from './title-resolver.pipe';
+
+describe('TitleResolverPipe', () => {
+  it('create an instance', () => {
+    const pipe = new TitleResolverPipe({} as any);
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/packages/core/src/router/title-resolver/title-resolver.pipe.ts
+++ b/packages/core/src/router/title-resolver/title-resolver.pipe.ts
@@ -1,0 +1,17 @@
+import { Optional, Pipe, PipeTransform } from '@angular/core';
+
+import { SdgRoute } from '../route.interface';
+import { resolveTitle } from '../router';
+import { TitleResolver } from './title-resolver';
+
+@Pipe({
+  name: 'titleResolver',
+  standalone: true
+})
+export class TitleResolverPipe implements PipeTransform {
+  constructor(@Optional() private titleResolver: TitleResolver) {}
+
+  transform(value: SdgRoute): string | undefined {
+    return resolveTitle(value, this.titleResolver);
+  }
+}

--- a/packages/core/src/router/title-resolver/title-resolver.ts
+++ b/packages/core/src/router/title-resolver/title-resolver.ts
@@ -8,7 +8,7 @@ import {
 } from '@angular/router';
 
 @Injectable()
-export abstract class TitleResolver<T> implements Resolve<T> {
+export abstract class TitleResolver<T = string> implements Resolve<T> {
   abstract resolve(
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot

--- a/packages/core/src/translation/index.ts
+++ b/packages/core/src/translation/index.ts
@@ -1,4 +1,5 @@
 export * from './translation.interface';
 export * from './translation.service';
 export * from './translation.provider';
+export * from './translation-mock.provider';
 export * from './translation.utils';

--- a/packages/core/src/translation/translation-mock.provider.ts
+++ b/packages/core/src/translation/translation-mock.provider.ts
@@ -1,0 +1,38 @@
+import { WritableSignal, signal } from '@angular/core';
+
+import { provideMockTranslation } from '@igo2/core/language';
+
+import { Observable, of } from 'rxjs';
+
+import { Language } from './translation.interface';
+import {
+  TranslationFeature,
+  TranslationFeatureKind
+} from './translation.provider';
+import { TranslationService } from './translation.service';
+
+export function withIgo2TranslationMock(): TranslationFeature<TranslationFeatureKind.Translation> {
+  return {
+    kind: TranslationFeatureKind.Translation,
+    providers: [
+      provideMockTranslation(),
+      { provide: TranslationService, useClass: TranslationServiceMock }
+    ]
+  };
+}
+
+export class TranslationServiceMock implements TranslationService {
+  lang: WritableSignal<Language> = signal('fr');
+
+  get(key: string | string[]): string {
+    return Array.isArray(key) ? key[0] : key;
+  }
+
+  getAsync(key: string | string[]): Observable<string> {
+    return of(Array.isArray(key) ? key[0] : key);
+  }
+
+  setLanguage() {
+    window.location.reload();
+  }
+}

--- a/packages/core/src/translation/translation.service.ts
+++ b/packages/core/src/translation/translation.service.ts
@@ -10,6 +10,12 @@ export abstract class TranslationService {
   abstract get(
     key: string | string[],
     interpolateParams?: Record<string, unknown>
+  ): string;
+
+  abstract getAsync(
+    key: string | string[],
+    interpolateParams?: Record<string, unknown>
   ): Observable<string>;
+
   abstract setLanguage(lang: Language): void;
 }

--- a/packages/src/lib/breadcrumb/breadcrumbs/breadcrumbs.component.ts
+++ b/packages/src/lib/breadcrumb/breadcrumbs/breadcrumbs.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Inject,
   OnDestroy,
   OnInit,
   Optional,
@@ -12,7 +11,7 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Route, Router, RouterModule } from '@angular/router';
 
-import { RouteTitleKey, TitleResolver, getRouteTitle } from '@igo2/sdg/core';
+import { RouteTitleKey, TitleResolver, resolveTitle } from '@igo2/sdg/core';
 
 import { Subject, takeUntil } from 'rxjs';
 
@@ -47,8 +46,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     @Optional()
-    @Inject(TitleResolver)
-    private titleResolver: TitleResolver<string>
+    private titleResolver: TitleResolver
   ) {}
 
   ngOnInit(): void {
@@ -116,7 +114,7 @@ export class BreadcrumbsComponent implements OnInit, OnDestroy {
        * @todo Gérer les title de route, le type peut être asynchrone comment gérer ça?
        * On pourrait diverger du type de @angular/router et forcer un string?
        */
-      const title = getRouteTitle(home, this.titleResolver) ?? '';
+      const title = resolveTitle(home, this.titleResolver) ?? '';
       const url = home.path ?? '';
       routes.unshift({
         id: `${title}-${url}`,

--- a/packages/src/lib/navigation/navigation.component.html
+++ b/packages/src/lib/navigation/navigation.component.html
@@ -17,7 +17,7 @@
               #rla="routerLinkActive"
               [active]="rla.isActive"
             >
-              {{ getTitle(link) }}
+              {{ link | titleResolver }}
             </a>
           }
         </nav>

--- a/packages/src/lib/navigation/navigation.component.ts
+++ b/packages/src/lib/navigation/navigation.component.ts
@@ -3,8 +3,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Inject,
-  Optional,
   computed,
   input,
   signal,
@@ -13,19 +11,15 @@ import {
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
-import { TitleResolver, getRouteTitle } from '@igo2/sdg/core';
+import { SdgRoutes, TitleResolverPipe } from '@igo2/sdg/core';
 
-import {
-  INavigationOptions,
-  INavigationRoute,
-  INavigationRoutes
-} from './navigation.interface';
+import { INavigationOptions } from './navigation.interface';
 
 @Component({
   selector: 'sdg-navigation',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, RouterLinkActive, MatTabsModule],
+  imports: [RouterLink, RouterLinkActive, MatTabsModule, TitleResolverPipe],
   templateUrl: './navigation.component.html',
   styleUrl: './navigation.component.scss',
   host: {
@@ -33,7 +27,7 @@ import {
   }
 })
 export class NavigationComponent implements AfterViewInit {
-  links = input.required<INavigationRoutes>();
+  links = input.required<SdgRoutes>();
   linksFiltered = computed(() => this.links().filter((link) => !link.hidden));
   isHandset = input.required<boolean>();
   options = input<INavigationOptions>();
@@ -43,18 +37,8 @@ export class NavigationComponent implements AfterViewInit {
   tabsContainer = viewChild<ElementRef<HTMLElement>>('tabsContainer');
   actionsContainer = viewChild<ElementRef<HTMLElement>>('actionsContainer');
 
-  constructor(
-    @Optional()
-    @Inject(TitleResolver)
-    private titleResolver: TitleResolver<string>
-  ) {}
-
   ngAfterViewInit(): void {
     this.handleOverflow();
-  }
-
-  getTitle(link: INavigationRoute): string | undefined {
-    return getRouteTitle(link, this.titleResolver);
   }
 
   /**

--- a/packages/src/lib/navigation/navigation.interface.ts
+++ b/packages/src/lib/navigation/navigation.interface.ts
@@ -1,12 +1,3 @@
-import { Route } from '@angular/router';
-
-export type INavigationRoutes = INavigationRoute[];
-
-export interface INavigationRoute extends Route {
-  /** Hidden in the primary tabs navigation */
-  hidden?: boolean;
-}
-
 export interface INavigationConfig {
   options?: INavigationOptions;
 }

--- a/projects/demo/public/locale/en.json
+++ b/projects/demo/public/locale/en.json
@@ -2,5 +2,8 @@
   "about": "About",
   "header": {
     "contactUs": "Contact us"
+  },
+  "showcases": {
+    "alsoSee": "Also see"
   }
 }

--- a/projects/demo/public/locale/fr.json
+++ b/projects/demo/public/locale/fr.json
@@ -2,5 +2,8 @@
   "about": "À propos",
   "header": {
     "contactUs": "Contactez-nous"
+  },
+  "showcases": {
+    "alsoSee": "À consulter aussi"
   }
 }

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -1,13 +1,13 @@
-import { INavigationRoutes } from '@igo2/sdg';
+import { RouteTranslateKey, SdgRoutes } from '@igo2/sdg/core';
 
 import { AppTitleResolver } from './config/title-resolver';
 
-export const routes: INavigationRoutes = [
+export const routes: SdgRoutes = [
   { path: '', redirectTo: '', pathMatch: 'full' },
   {
     path: '',
     title: AppTitleResolver,
-    data: { title: 'about' },
+    data: { [RouteTranslateKey]: 'about' },
     loadComponent: () =>
       import('./pages/about/about.component').then((m) => m.AboutComponent)
   },
@@ -27,7 +27,7 @@ export const routes: INavigationRoutes = [
     path: 'contact-us',
     title: AppTitleResolver,
     data: {
-      title: 'header.contactUs'
+      [RouteTranslateKey]: 'header.contactUs'
     },
     hidden: true,
     loadComponent: () =>

--- a/projects/demo/src/app/config/title-resolver.ts
+++ b/projects/demo/src/app/config/title-resolver.ts
@@ -1,26 +1,32 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Data, Route } from '@angular/router';
 
-import { RouteTitleKey, TitleResolver } from '@igo2/sdg/core';
+import {
+  RouteTitleKey,
+  RouteTranslateKey,
+  TitleResolver
+} from '@igo2/sdg/core';
 
 import { Observable, tap } from 'rxjs';
 
 import { AppTranslationService } from './translation/translation.service';
 
 @Injectable({ providedIn: 'root' })
-export class AppTitleResolver implements TitleResolver<string> {
+export class AppTitleResolver implements TitleResolver {
   constructor(private translationService: AppTranslationService) {}
 
   resolve(route: ActivatedRouteSnapshot): Observable<string> {
-    return this.translationService.translate.get(route.data.title ?? '').pipe(
-      tap((value) => {
-        if (!route.routeConfig) {
-          return;
-        }
+    return this.translationService
+      .getAsync(route.data[RouteTranslateKey] ?? '')
+      .pipe(
+        tap((value) => {
+          if (!route.routeConfig) {
+            return;
+          }
 
-        this.setRouteDataTitle(value, route.routeConfig.data);
-      })
-    );
+          this.setRouteDataTitle(value, route.routeConfig.data);
+        })
+      );
   }
 
   resolveStatic(route: Route | null): string | undefined {
@@ -28,8 +34,8 @@ export class AppTitleResolver implements TitleResolver<string> {
       return;
     }
 
-    const value = this.translationService.translate.instant(
-      route.data?.title ?? ''
+    const value = this.translationService.get(
+      route.data?.[RouteTranslateKey] ?? ''
     );
 
     this.setRouteDataTitle(value, route.data);

--- a/projects/demo/src/app/config/translation/translation.service.ts
+++ b/projects/demo/src/app/config/translation/translation.service.ts
@@ -31,6 +31,13 @@ export class AppTranslationService
   get(
     key: string | string[],
     interpolateParams?: Record<string, unknown>
+  ): string {
+    return this.translate.instant(key, interpolateParams);
+  }
+
+  getAsync(
+    key: string | string[],
+    interpolateParams?: Record<string, unknown>
   ): Observable<string> {
     return this.translate.get(key, interpolateParams);
   }

--- a/projects/demo/src/app/pages/components/components.component.html
+++ b/projects/demo/src/app/pages/components/components.component.html
@@ -2,7 +2,9 @@
   <ul>
     @for (route of routes; track route) {
       <li>
-        <a [routerLink]="['showcases', route.path]">{{ route.title }}</a>
+        <a [routerLink]="['showcases', route.path]">{{
+          route | titleResolver
+        }}</a>
       </li>
     }
   </ul>

--- a/projects/demo/src/app/pages/components/components.component.ts
+++ b/projects/demo/src/app/pages/components/components.component.ts
@@ -1,7 +1,8 @@
 import { Component, Signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
-import { BasicScreenComponent, INavigationRoutes } from '@igo2/sdg';
+import { BasicScreenComponent } from '@igo2/sdg';
+import { SdgRoutes, TitleResolverPipe } from '@igo2/sdg/core';
 
 import { AppService } from '../../app.service';
 import { routes } from './showcases/showcases.routes';
@@ -9,14 +10,12 @@ import { routes } from './showcases/showcases.routes';
 @Component({
   selector: 'app-components',
   standalone: true,
-  imports: [BasicScreenComponent, RouterLink],
+  imports: [BasicScreenComponent, RouterLink, TitleResolverPipe],
   templateUrl: './components.component.html',
   styleUrl: './components.component.scss'
 })
 export class ComponentsComponent {
-  routes: INavigationRoutes = routes.filter(
-    (route) => route.redirectTo == null
-  );
+  routes: SdgRoutes = routes.filter((route) => route.redirectTo == null);
 
   constructor(private appService: AppService) {}
 

--- a/projects/demo/src/app/pages/components/components.routes.ts
+++ b/projects/demo/src/app/pages/components/components.routes.ts
@@ -1,6 +1,6 @@
-import { INavigationRoutes } from '@igo2/sdg';
+import { SdgRoutes } from '@igo2/sdg/core';
 
-export const routes: INavigationRoutes = [
+export const routes: SdgRoutes = [
   { path: '', redirectTo: '', pathMatch: 'full' },
   {
     path: '',

--- a/projects/demo/src/app/pages/components/showcases/showcases.component.html
+++ b/projects/demo/src/app/pages/components/showcases/showcases.component.html
@@ -2,7 +2,7 @@
   <ul left-slot>
     @for (route of routes; track route) {
       <li>
-        <a [routerLink]="[route.path]">{{ route.title }}</a>
+        <a [routerLink]="[route.path]">{{ route | titleResolver }}</a>
       </li>
     }
   </ul>

--- a/projects/demo/src/app/pages/components/showcases/showcases.component.ts
+++ b/projects/demo/src/app/pages/components/showcases/showcases.component.ts
@@ -3,7 +3,7 @@ import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { RouterLink } from '@angular/router';
 
 import { SplitScreenComponent } from '@igo2/sdg';
-import { getRouteTitle } from '@igo2/sdg/core';
+import { TitleResolverPipe } from '@igo2/sdg/core';
 
 import { Subject, filter, takeUntil } from 'rxjs';
 
@@ -13,7 +13,8 @@ import { routes } from './showcases.routes';
 @Component({
   selector: 'app-showcases',
   standalone: true,
-  imports: [SplitScreenComponent, RouterOutlet, RouterLink],
+  imports: [SplitScreenComponent, RouterOutlet, RouterLink, TitleResolverPipe],
+  providers: [TitleResolverPipe],
   templateUrl: './showcases.component.html',
   styleUrl: './showcases.component.scss'
 })
@@ -25,7 +26,8 @@ export class ShowcasesComponent implements OnDestroy {
 
   constructor(
     private appService: AppService,
-    private router: Router
+    private router: Router,
+    private titleResolverPipe: TitleResolverPipe
   ) {
     this.router.events
       .pipe(
@@ -51,7 +53,7 @@ export class ShowcasesComponent implements OnDestroy {
         });
 
         if (config) {
-          this.title.set(getRouteTitle(config));
+          this.title.set(this.titleResolverPipe.transform(config));
         }
       });
   }

--- a/projects/demo/src/app/pages/components/showcases/showcases.routes.ts
+++ b/projects/demo/src/app/pages/components/showcases/showcases.routes.ts
@@ -1,10 +1,15 @@
-import { INavigationRoutes } from '@igo2/sdg';
+import { RouteTranslateKey, SdgRoutes } from '@igo2/sdg/core';
 
-export const routes: INavigationRoutes = [
+import { AppTitleResolver } from '../../../config/title-resolver';
+
+export const routes: SdgRoutes = [
   { path: '', redirectTo: 'breadcrumb', pathMatch: 'full' },
   {
     path: 'a-consulter-aussi',
-    title: 'À consulter aussi',
+    title: AppTitleResolver,
+    data: {
+      [RouteTranslateKey]: 'showcases.alsoSee'
+    },
     loadComponent: () =>
       import('./consult/consult.component').then((m) => m.ConsultDemoComponent)
   },

--- a/projects/demo/src/app/pages/contact-us/contact-us.component.ts
+++ b/projects/demo/src/app/pages/contact-us/contact-us.component.ts
@@ -2,8 +2,7 @@ import { Component, Signal } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { BasicScreenComponent } from '@igo2/sdg';
-
-import { RouteTitleKey } from 'packages/core';
+import { RouteTitleKey } from '@igo2/sdg/core';
 
 import { AppService } from '../../app.service';
 

--- a/projects/demo/src/test-config.ts
+++ b/projects/demo/src/test-config.ts
@@ -3,17 +3,22 @@ import { TestModuleMetadata } from '@angular/core/testing';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
-import { provideMockTranslation } from '@igo2/core/language';
-import { provideTranslation, withIgo2Translation } from '@igo2/sdg/core';
+import {
+  provideTranslation,
+  withIgo2TranslationMock,
+  withRouterTitleResolver
+} from '@igo2/sdg/core';
 
-import { AppTranslationService } from './app/config/translation/translation.service';
+import { AppTitleResolver } from './app/config/title-resolver';
 
 export const TEST_CONFIG: TestModuleMetadata = {
   providers: [
     provideRouter([]),
-    provideMockTranslation(),
     provideHttpClientTesting(),
-    provideTranslation(withIgo2Translation({}, AppTranslationService)),
+    provideTranslation(
+      withIgo2TranslationMock(),
+      withRouterTitleResolver(AppTitleResolver)
+    ),
     provideAnimations()
   ]
 };


### PR DESCRIPTION
J'ai ajouté plus d'exemples pour la translation via le titlte d'une configuration de route. Entre autre pour le showcases et pouvoir tester ta PR de block-link avec le `INavigationRoute`.