### PR TITLE
feat: add isHome property to routes and update breadcrumb logic

### DIFF
--- a/packages/core/src/router/route.interface.ts
+++ b/packages/core/src/router/route.interface.ts
@@ -3,6 +3,7 @@ import { Route } from '@angular/router';
 export type SdgRoutes = SdgRoute[];
 
 export interface SdgRoute extends Route {
+  isHome?: boolean;
   description?: string;
   /** Hidden in the primary tabs navigation */
   hidden?: boolean;

--- a/packages/core/src/typography/typography.scss
+++ b/packages/core/src/typography/typography.scss
@@ -149,7 +149,7 @@ $font-color: colors.$blue-dark;
   .accroche {
     font-size: 18px;
     line-height: 28px;
-    font-weight: 600px;
+    font-weight: 600;
     max-width: 82.5rem;
     padding-bottom: 24px;
   }

--- a/packages/src/lib/breadcrumbs/breadcrumbs-with-router.component.ts
+++ b/packages/src/lib/breadcrumbs/breadcrumbs-with-router.component.ts
@@ -6,9 +6,14 @@ import {
   Optional,
   signal
 } from '@angular/core';
-import { ActivatedRoute, Route, Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
-import { RouteTitleKey, TitleResolver, resolveTitle } from '@igo2/sdg/core';
+import {
+  RouteTitleKey,
+  SdgRoute,
+  TitleResolver,
+  resolveTitle
+} from '@igo2/sdg/core';
 
 import { Subject, takeUntil } from 'rxjs';
 
@@ -67,41 +72,43 @@ export class BreadcrumbsWithRouterComponent
     this._takeUntil.next(true);
   }
 
-  private getHomeRoute(): Route | undefined {
-    return this.router.config
-      .filter((route) => route.redirectTo == null)
-      .find((route) => route.path === '');
+  private getHomeRoute(): SdgRoute | undefined {
+    return this.router.config.find((route: SdgRoute) => route.isHome);
   }
 
   private getBreadsFromRouterSegments(): Breadcrumbs {
     const routes = this.getRouterBreadcrumbs();
+    if (!routes.length) {
+      return [];
+    }
+
+    const home = this.getHomeRoute();
+    if (!home) {
+      throw new Error(
+        'We need at least one home to construct the breadcrumbs list. You need to setup a route with the isHome property at true'
+      );
+    }
     /**
      * Si on est sur la route du parent "", on n'affiche aucune route?
      * @todo Cette logique est à discuté et analysé pour voir comment gérer ce comportement et
      * sur une stratégie pour gérer cette configuration. Par exemple le système gouvernemental met
      * le libellé "Accueil" avec une redirection vers la route "a-propos"
      */
-    const home = this.getHomeRoute();
-    if (
-      (routes.length && routes[0]?.title === home?.title) ||
-      routes[0]?.title === home?.data?.[RouteTitleKey]
-    ) {
+    if (routeEqualHome(routes[0], home)) {
       return [];
     }
 
-    if (home) {
-      /**
-       * @todo Gérer les title de route, le type peut être asynchrone comment gérer ça?
-       * On pourrait diverger du type de @angular/router et forcer un string?
-       */
-      const title = resolveTitle(home, this.titleResolver) ?? '';
-      const url = home.path ?? '';
-      routes.unshift({
-        id: `${title}-${url}`,
-        title,
-        url
-      });
-    }
+    /**
+     * @todo Gérer les title de route, le type peut être asynchrone comment gérer ça?
+     * On pourrait diverger du type de @angular/router et forcer un string?
+     */
+    const title = resolveTitle(home, this.titleResolver) ?? '';
+    const url = home.path ?? '';
+    routes.unshift({
+      id: `${title}-${url}`,
+      title,
+      url
+    });
 
     return routes;
   }
@@ -135,4 +142,14 @@ export class BreadcrumbsWithRouterComponent
       return breadcrumbs.concat(breadcrumb);
     }, [] as Breadcrumbs);
   }
+}
+
+function routeEqualHome(route: SdgRoute, home: SdgRoute | undefined): boolean {
+  if (!home) {
+    return false;
+  }
+
+  return (
+    route.title === home.title || route.title === home.data?.[RouteTitleKey]
+  );
 }

--- a/projects/demo/public/locale/en.json
+++ b/projects/demo/public/locale/en.json
@@ -1,5 +1,4 @@
 {
-
   "header": {
     "contactUs": "Contact us"
   },

--- a/projects/demo/public/locale/fr.json
+++ b/projects/demo/public/locale/fr.json
@@ -1,5 +1,4 @@
 {
-
   "header": {
     "contactUs": "Nous joindre"
   },

--- a/projects/demo/src/app/app.routes.ts
+++ b/projects/demo/src/app/app.routes.ts
@@ -3,9 +3,15 @@ import { RouteTranslateKey, SdgRoutes } from '@igo2/sdg/core';
 import { AppTitleResolver } from './config/title-resolver';
 
 export const routes: SdgRoutes = [
-  { path: '', redirectTo: '', pathMatch: 'full' },
   {
     path: '',
+    redirectTo: '',
+    pathMatch: 'full',
+    hidden: true
+  },
+  {
+    path: '',
+    isHome: true,
     title: AppTitleResolver,
     data: { [RouteTranslateKey]: 'navigation.about' },
     loadComponent: () =>


### PR DESCRIPTION
Pour corriger des bogues de détection, je propose de déclarer de manière statique qui est la route parente. Ça va nous permettre plus de contrôles et de stabilités