### PR TITLE
fix(core): button theme - customized with the overrides mixins

### DIFF
--- a/packages/core/src/style/overrides/material/_button-theme.scss
+++ b/packages/core/src/style/overrides/material/_button-theme.scss
@@ -19,10 +19,14 @@
 
 @mixin density($theme) {
   .mdc-button {
-    --mdc-text-button-container-height: 56px;
-    --mdc-outlined-button-container-height: 56px;
-    --mdc-protected-button-container-height: 56px;
-    --mdc-filled-button-container-height: 56px;
+    @include mat.button-overrides(
+      (
+        filled-container-height: 56px,
+        outlined-container-height: 56px,
+        protected-container-height: 56px,
+        text-container-height: 56px
+      )
+    );
     min-width: calc(56px * 2) !important;
   }
 
@@ -57,17 +61,20 @@
 
 @mixin typography($theme) {
   .mdc-button {
-    --mdc-text-button-label-text-weight: bold;
-    --mdc-outlined-button-label-text-weight: bold;
-    --mdc-protected-button-label-text-weight: bold;
-    --mdc-filled-button-label-text-weight: bold;
-
     $font-size: mat.m2-font-size(typography.$typography, body-1);
 
-    --mdc-filled-button-label-text-size: $font-size;
-    --mdc-text-button-label-text-size: $font-size;
-    --mdc-outlined-button-label-text-size: $font-size;
-    --mdc-protected-button-label-text-size: $font-size;
+    @include mat.button-overrides(
+      (
+        filled-label-text-size: $font-size,
+        filled-label-text-weight: bold,
+        outlined-label-text-size: $font-size,
+        outlined-label-text-weight: bold,
+        protected-label-text-size: $font-size,
+        protected-label-text-weight: bold,
+        text-label-text-size: $font-size,
+        text-label-text-weight: bold
+      )
+    );
 
     line-height: mat.m2-line-height(typography.$typography, body-1) !important;
   }


### PR DESCRIPTION
On utilise les mixins au lieu des variables directement, ça semble corriger le bogue
https://v19.material.angular.dev/components/button/styling