### PR TITLE
fix(footer): isolate copyright url and links arrangement

### DIFF
--- a/packages/common/src/footer/footer-copyright/footer-copyright.component.html
+++ b/packages/common/src/footer/footer-copyright/footer-copyright.component.html
@@ -11,7 +11,7 @@
     /></a>
     <a
       class="sdg-footer-copyright-copyright"
-      href="https://www.quebec.ca/droit-auteur"
+      [href]="copyright().copyrightUrl"
       target="_blank"
       >© Gouvernement du Québec, {{ year() }}</a
     >

--- a/packages/common/src/footer/footer-copyright/footer-copyright.component.ts
+++ b/packages/common/src/footer/footer-copyright/footer-copyright.component.ts
@@ -18,6 +18,9 @@ export class FooterCopyrightComponent {
   readonly copyright = input.required<FooterCopyright>();
   readonly containerClass = input<string>();
 
+  readonly url = computed(
+    () => this.copyright().copyrightUrl || 'https://www.quebec.ca/droit-auteur'
+  );
   readonly year = computed(
     () => this.copyright().year || new Date().getFullYear()
   );

--- a/packages/common/src/footer/footer-links/footer-links.component.scss
+++ b/packages/common/src/footer/footer-links/footer-links.component.scss
@@ -1,7 +1,8 @@
 .sdg-footer-links {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
-  column-gap: 32px;
+  gap: 8px 32px;
 
   &-link {
     font-size: 14px;

--- a/packages/common/src/footer/footer.interface.ts
+++ b/packages/common/src/footer/footer.interface.ts
@@ -21,5 +21,6 @@ export interface SiteMapLink {
 export interface FooterCopyright {
   logo: string;
   logoUrl: string;
+  copyrightUrl?: string;
   year?: number;
 }


### PR DESCRIPTION
Changement de l'alignement des liens du footer et isolation de l'URL du copyright pour pouvoir spécifier un lien anglais, par exemple.