### PR TITLE
fix: allow custom initial extent

### DIFF
--- a/packages/carto/ol/src/map/map.ts
+++ b/packages/carto/ol/src/map/map.ts
@@ -44,8 +44,8 @@ export class SdgOlMap implements ISdgMap<olMap> {
     return this.engine.getView();
   }
 
-  setInitialExtent(): void {
-    this.initialExtent = this.getExtent();
+  setInitialExtent(extent?: Extent): void {
+    this.initialExtent = extent ? extent : this.getExtent();
   }
 
   getExtent(): Extent {

--- a/packages/carto/src/shared/map.interface.ts
+++ b/packages/carto/src/shared/map.interface.ts
@@ -5,7 +5,7 @@ export interface ISdgMap<T = unknown> {
   readonly options: IMapBaseOptions;
   initialExtent: Extent | undefined;
 
-  setInitialExtent(): void;
+  setInitialExtent(extent?: Extent): void;
   getExtent(): Extent;
   setTarget(id: string | HTMLElement | undefined): void;
   fit(extent: Extent): void;


### PR DESCRIPTION
Il est possible qu'on l'on veuille revenir à une vue spécifique et non à la vue à l'initialisation de la carte. Par exemple, dans QEA on veut revenir sur l'extent d'une zone d'alerte.