### PR TITLE
fix: background color of form fields and outlined buttons

### DIFF
--- a/packages/core/src/style/overrides/material/_button.scss
+++ b/packages/core/src/style/overrides/material/_button.scss
@@ -72,6 +72,7 @@
   .mat-mdc-outlined-button {
     border-color: currentColor !important;
     border-width: 2px !important;
+    background-color: var(--sdg-color-white) !important;
 
     &[compact] {
       border-width: 1px !important;

--- a/packages/core/src/style/overrides/material/_button.scss
+++ b/packages/core/src/style/overrides/material/_button.scss
@@ -72,7 +72,7 @@
   .mat-mdc-outlined-button {
     border-color: currentColor !important;
     border-width: 2px !important;
-    background-color: var(--sdg-color-white) !important;
+    background-color: var(--sdg-color-background) !important;
 
     &[compact] {
       border-width: 1px !important;

--- a/packages/core/src/style/overrides/material/_form-field.scss
+++ b/packages/core/src/style/overrides/material/_form-field.scss
@@ -55,6 +55,7 @@
     }
 
     .mdc-text-field {
+      background-color: var(--sdg-color-white);
       padding: 0 8px;
 
       &--focused {

--- a/packages/core/src/style/overrides/material/_form-field.scss
+++ b/packages/core/src/style/overrides/material/_form-field.scss
@@ -55,7 +55,7 @@
     }
 
     .mdc-text-field {
-      background-color: var(--sdg-color-white);
+      background-color: var(--sdg-color-background);
       padding: 0 8px;
 
       &--focused {

--- a/packages/core/src/style/overrides/material/_select.scss
+++ b/packages/core/src/style/overrides/material/_select.scss
@@ -32,7 +32,7 @@
       (
         container-elevation-shadow: none,
         //
-        panel-background-color: white
+        panel-background-color: var(--sdg-color-background)
       )
     );
 

--- a/projects/demo/src/app/pages/components/showcases/checkbox/checkbox.component.html
+++ b/projects/demo/src/app/pages/components/showcases/checkbox/checkbox.component.html
@@ -22,7 +22,7 @@
   </div>
   <button
     compact
-    mat-stroked-button
+    matButton="outlined"
     color="primary"
     (click)="
       this.disabled1.set(!this.disabled1());
@@ -44,7 +44,7 @@
   </div>
   <button
     compact
-    mat-stroked-button
+    matButton="outlined"
     color="primary"
     (click)="
       this.disabledCompact1.set(!this.disabledCompact1());

--- a/projects/demo/src/app/pages/components/showcases/chips/chips.component.html
+++ b/projects/demo/src/app/pages/components/showcases/chips/chips.component.html
@@ -72,7 +72,7 @@
   </form>
   <button
     compact
-    mat-stroked-button
+    matButton="outlined"
     (click)="selectorChipsDisabled.set(!selectorChipsDisabled())"
   >
     {{ selectorChipsDisabled() ? 'Activer' : 'Désactiver' }}
@@ -108,7 +108,7 @@
   </mat-chip-listbox>
   <button
     compact
-    mat-stroked-button
+    matButton="outlined"
     (click)="navigationChipsDisabled.set(!navigationChipsDisabled())"
   >
     {{ navigationChipsDisabled() ? 'Activer' : 'Désactiver' }}

--- a/projects/demo/src/app/pages/components/showcases/form-field/form-field.component.html
+++ b/projects/demo/src/app/pages/components/showcases/form-field/form-field.component.html
@@ -121,7 +121,7 @@
     </div>
     <button
       compact
-      mat-stroked-button
+      matButton="outlined"
       color="primary"
       (click)="this.disabled1.set(!this.disabled1())"
     >
@@ -202,7 +202,7 @@
     </div>
     <button
       compact
-      mat-stroked-button
+      matButton="outlined"
       color="primary"
       (click)="this.disabled2.set(!this.disabled2())"
     >
@@ -272,7 +272,7 @@
     </div>
     <button
       compact
-      mat-stroked-button
+      matButton="outlined"
       color="primary"
       (click)="this.disabled3.set(!this.disabled3())"
     >

--- a/projects/demo/src/app/pages/components/showcases/form-field/form-field.component.spec.ts
+++ b/projects/demo/src/app/pages/components/showcases/form-field/form-field.component.spec.ts
@@ -222,9 +222,7 @@ describe('FormFieldDemoComponent', () => {
 
   describe('Button behavior', () => {
     it('should render toggle buttons', () => {
-      const buttons = fixture.debugElement.queryAll(
-        By.css('button[mat-stroked-button]')
-      );
+      const buttons = fixture.debugElement.queryAll(By.css('button'));
       expect(buttons.length).toBe(3);
     });
 

--- a/projects/demo/src/app/pages/components/showcases/radio-button/radio-button.component.html
+++ b/projects/demo/src/app/pages/components/showcases/radio-button/radio-button.component.html
@@ -35,7 +35,7 @@
     <div class="buttons">
       <button
         compact
-        mat-stroked-button
+        matButton="outlined"
         color="primary"
         (click)="
           this.disabled1.set(!this.disabled1());
@@ -46,7 +46,7 @@
       </button>
       <button
         compact
-        mat-stroked-button
+        matButton="outlined"
         color="primary"
         [disabled]="!checked1() && !checked2()"
         (click)="this.checked1.set(false); this.checked2.set(false)"
@@ -83,7 +83,7 @@
     <div class="buttons">
       <button
         compact
-        mat-stroked-button
+        matButton="outlined"
         color="primary"
         (click)="
           this.disabledCompact1.set(!this.disabledCompact1());
@@ -96,7 +96,7 @@
       </button>
       <button
         compact
-        mat-stroked-button
+        matButton="outlined"
         color="primary"
         [disabled]="!checkedCompact1() && !checkedCompact2()"
         (click)="

--- a/projects/demo/src/app/pages/components/showcases/select/select.component.html
+++ b/projects/demo/src/app/pages/components/showcases/select/select.component.html
@@ -111,7 +111,7 @@
     </div>
     <button
       compact
-      mat-stroked-button
+      matButton="outlined"
       color="primary"
       (click)="this.disabled1.set(!this.disabled1())"
     >
@@ -184,7 +184,7 @@
     </div>
     <button
       compact
-      mat-stroked-button
+      matButton="outlined"
       color="primary"
       (click)="this.disabled2.set(!this.disabled2())"
     >

--- a/projects/demo/src/app/pages/components/showcases/select/select.component.spec.ts
+++ b/projects/demo/src/app/pages/components/showcases/select/select.component.spec.ts
@@ -220,9 +220,7 @@ describe('SelectDemoComponent', () => {
 
   describe('Button behavior', () => {
     it('should render toggle buttons', () => {
-      const buttons = fixture.debugElement.queryAll(
-        By.css('button[mat-stroked-button]')
-      );
+      const buttons = fixture.debugElement.queryAll(By.css('button'));
       expect(buttons.length).toBe(2);
     });
 


### PR DESCRIPTION
Correction de la couleur des `mat-form-field` et `matButton="outlined"`