### PR TITLE
fix(common): adjusted height of logo and url

### DIFF
--- a/packages/common/src/footer/footer-copyright/footer-copyright.component.scss
+++ b/packages/common/src/footer/footer-copyright/footer-copyright.component.scss
@@ -16,7 +16,7 @@
       display: flex;
 
       &-logo {
-        height: 35px;
+        height: 50px;
       }
     }
 

--- a/projects/demo/src/environments/environment.prod.ts
+++ b/projects/demo/src/environments/environment.prod.ts
@@ -30,7 +30,8 @@ export const environment: EnvironmentOptions = {
   footer: {
     copyright: {
       logo: 'images/piv-pied-page.svg',
-      logoUrl: 'https://www.quebec.ca/gouvernement/ministere/securite-publique'
+      logoUrl:
+        'https://www.quebec.ca/gouvernement/ministere/securite-interieure'
     }
   }
 };


### PR DESCRIPTION
Changement de la hauteur du logo du copyright.

<img width="364" height="219" alt="image" src="https://github.com/user-attachments/assets/7321a45a-6f86-483b-981f-d9fb3f651255" />
