### PR TITLE
fix(common): sequential link text alignment

### DIFF
--- a/packages/common/src/sequential-links/sequential-links.component.scss
+++ b/packages/common/src/sequential-links/sequential-links.component.scss
@@ -6,6 +6,7 @@
 
 .sdg-sequential-links {
   &-arrow {
+    flex-shrink: 0;
     color: var(--sdg-color-text);
     font-variation-settings: 'wght' 350;
   }

--- a/packages/common/src/sequential-links/sequential-links.component.scss
+++ b/packages/common/src/sequential-links/sequential-links.component.scss
@@ -52,7 +52,7 @@
   &-title,
   &-text {
     font-size: 16px;
-    align-self: flex-start;
+    text-align: left;
   }
 
   &-title {


### PR DESCRIPTION
Lorsque le texte est très long, le texte était mal aligné. Il est mainteant aligné à gauche.