### PR TITLE
fix(common): margin 0 only first and last elements

### DIFF
--- a/packages/common/src/alert/alert.component.scss
+++ b/packages/common/src/alert/alert.component.scss
@@ -53,7 +53,14 @@
     ::ng-deep * {
       font-size: var(--sdg-font-size-md) !important;
       font-weight: var(--sdg-font-weight-semi-bold);
-      margin: 0 !important;
+
+      &:first-child {
+        margin-top: 0 !important;
+      }
+
+      &:last-child {
+        margin-bottom: 0 !important;
+      }
 
       @include sdg.media(mobile) {
         font-size: var(--sdg-font-size-sm) !important;

--- a/packages/common/src/notice/notice.component.scss
+++ b/packages/common/src/notice/notice.component.scss
@@ -74,9 +74,16 @@
 
     &-message {
       ::ng-deep * {
-        margin: 0 !important;
         font-size: var(--sdg-font-size-sm) !important;
         line-height: var(--sdg-line-height-90) !important;
+
+        &:first-child {
+          margin-top: 0 !important;
+        }
+
+        &:last-child {
+          margin-bottom: 0 !important;
+        }
       }
     }
   }


### PR DESCRIPTION
On veut seulement mettre les marges nulles sur le premier et le dernier élément, afin de conserver l'espacement naturel dans l'éventualité où il y a plusieurs lignes de contenu.