### PR TITLE
fix(dialog): specify button selector for dialog close action

### DIFF
--- a/packages/theme/src/material/_dialog.scss
+++ b/packages/theme/src/material/_dialog.scss
@@ -51,7 +51,7 @@
     );
 
     .mat-mdc-dialog-surface {
-      button[matIconButton] {
+      button[matIconButton][mat-dialog-close] {
         position: absolute;
         top: 8px;
         right: 8px;


### PR DESCRIPTION
Pour éviter ce genre d'interférence de style

<img width="1912" height="954" alt="image" src="https://github.com/user-attachments/assets/9f81790b-1412-4c3e-a89c-f01e1e64231a" />
